### PR TITLE
Make team VMs using StatefulSets

### DIFF
--- a/templates/manifests/teams.yml
+++ b/templates/manifests/teams.yml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: katana-teams
 spec:


### PR DESCRIPTION
Using StatefulSets for team VMs as we want their pod names and disk to persist after any kind of failure.
