### PR TITLE
[Minor] Remove Deployment label from manifest

### DIFF
--- a/manifests/templates/broadcast-service.yml
+++ b/manifests/templates/broadcast-service.yml
@@ -5,7 +5,6 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    deployment: {{.DeploymentLabel}}
     app: {{.BroadcastLabel}}
   ports:
     - protocol: TCP

--- a/manifests/templates/broadcast.yml
+++ b/manifests/templates/broadcast.yml
@@ -10,7 +10,6 @@ spec:
   template:
     metadata:
       labels:
-        deployment: {{.DeploymentLabel}}
         app: {{.BroadcastLabel}}
     spec:
       containers:


### PR DESCRIPTION
Katana fails to build because of unparsed deployed labels

Signed-off-by: Gaurav Genani <h3llix.pvt@gmail.com>