### PR TITLE
[WIP] Team VM Network Policies

### DIFF
--- a/manifests/templates/team-network-policy.yml
+++ b/manifests/templates/team-network-policy.yml
@@ -1,16 +1,36 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: team-vm-policy
+  namespace: katana-teams
+spec:
+  podSelector: {}
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          networking/namespace: katana-teams
+---
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
-  name: test-network-policy
+  name: allow-internet-only
   namespace: katana-teams
 spec:
+  podSelector: {}
   policyTypes:
   - Egress
-  podSelector:
-    matchLabels:
-      networking/allow-internet-egress: "true"
-  # egress:
-  # - to:
-  #   - namespaceSelector:
-  #     matchLabels:
+  egress:
+  - ports:
+    - protocol: TCP
+      port: 53
+    - protocol: UDP
+      port: 53
+  - to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+
+
 

--- a/manifests/templates/team-network-policy.yml
+++ b/manifests/templates/team-network-policy.yml
@@ -1,0 +1,16 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: test-network-policy
+  namespace: katana-teams
+spec:
+  policyTypes:
+  - Egress
+  podSelector:
+    matchLabels:
+      networking/allow-internet-egress: "true"
+  # egress:
+  # - to:
+  #   - namespaceSelector:
+  #     matchLabels:
+

--- a/manifests/templates/teams.yml
+++ b/manifests/templates/teams.yml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: katana-teams
+  labels:
+    networking/namespace: katana-teams    
 ---
 kind: ConfigMap
 apiVersion: v1

--- a/manifests/templates/teams.yml
+++ b/manifests/templates/teams.yml
@@ -1,7 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: katana-teams
+---
 kind: ConfigMap
 apiVersion: v1
 metadata:
   name: teamvm-config
+  namespace: katana-teams
 data:
     challenge_dir: {{.ChallengDir}}
     tmp_dir: {{.TempDir}} 
@@ -12,6 +18,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: katana-teams
+  namespace: katana-teams
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
Adds Network Policies to prevent team VMs from being able to communicate with katana's core services